### PR TITLE
chore: update web-sdk to v0.2.0-dev.21

### DIFF
--- a/public/launch.html
+++ b/public/launch.html
@@ -61,7 +61,7 @@
     <!-- Tiro Web SDK CSS -->
     <link
       rel="stylesheet"
-      href="https://atticus-assets.tiro.health/sdk-dev/latest/tiro-web-sdk.css"
+      href="https://atticus-assets.tiro.health/sdk-dev/v0.2.0-dev.21/style.css"
     />
 
     <style>
@@ -246,7 +246,7 @@
     </div>
 
     <!-- Tiro Web SDK IIFE Bundle -->
-    <script src="https://atticus-assets.tiro.health/sdk-dev/latest/tiro-web-sdk.iife.js"></script>
+    <script src="https://atticus-assets.tiro.health/sdk-dev/v0.2.0-dev.21/tiro-web-sdk.iife.js"></script>
 
     <script>
       // ============================================


### PR DESCRIPTION
## Summary
- Pin Tiro Web SDK to version `v0.2.0-dev.21` instead of `latest`
- Update both CSS (`style.css`) and JS (`tiro-web-sdk.iife.js`) CDN paths

## Test plan
- [ ] Verify SDK loads correctly at http://localhost:5174/launch.html
- [ ] Confirm form filler and magic clipboard components work as expected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)