### PR TITLE
Fix unwanted scrollbar on form filler container

### DIFF
--- a/public/launch.html
+++ b/public/launch.html
@@ -318,10 +318,10 @@
         </div>
       </details>
 
-      <div class="flex-1 min-h-0 overflow-auto">
+      <div class="flex-1 min-h-0 overflow-hidden">
         <tiro-form-filler
           id="report-form"
-          sdc-endpoint-address="https://sdc.tiro.health/fhir/r5"
+          sdc-endpoint-address="https://sdc-staging.tiro.health/fhir/r5"
           compact-grouping
         />
       </div>


### PR DESCRIPTION
## Summary
- Change `overflow-auto` to `overflow-hidden` on the `tiro-form-filler` wrapper div to prevent a double scrollbar
- Update SDC endpoint to staging

## Test plan
- [ ] Open launch.html and verify no extra scrollbar appears on the form filler container

🤖 Generated with [Claude Code](https://claude.com/claude-code)